### PR TITLE
UpdatePrefabsForROS2FrameEditorComponent

### DIFF
--- a/Assets/OTTO1500/OTTO1500_Basic_platform.prefab
+++ b/Assets/OTTO1500/OTTO1500_Basic_platform.prefab
@@ -86,13 +86,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 15925498669316666254
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 15123522658220298039,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent"
-                    }
-                },
                 "ROS2Lidar2DSensorComponent": {
                     "$type": "GenericComponentWrapper",
                     "Id": 1224177359147313595,
@@ -133,6 +126,11 @@
                             89.99998474121094
                         ]
                     }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 15123522658220298039,
+                    "ROS2FrameConfiguration": {}
                 }
             }
         },
@@ -171,13 +169,6 @@
                 "EditorVisibilityComponent": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 15925498669316666254
-                },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 15123522658220298039,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent"
-                    }
                 },
                 "ROS2Lidar2DSensorComponent": {
                     "$type": "GenericComponentWrapper",
@@ -219,6 +210,11 @@
                             -89.99999237060547
                         ]
                     }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 15123522658220298039,
+                    "ROS2FrameConfiguration": {}
                 }
             }
         },
@@ -427,15 +423,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 16022502127876327237
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 7074193684611987849,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_FL",
-                        "Joint Name": "wheel_FL_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 4980933094791522169,
@@ -446,6 +433,14 @@
                             0.47581198811531067,
                             0.09000000357627869
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 7074193684611987849,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_FL",
+                        "Joint Name": "wheel_FL_joint"
                     }
                 }
             }
@@ -562,15 +557,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 2443215881953371120
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 9575629714018252231,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_FR",
-                        "Joint Name": "wheel_FR_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 3306116615541045982,
@@ -581,6 +567,14 @@
                             -0.47581198811531067,
                             0.09000000357627869
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 9575629714018252231,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_FR",
+                        "Joint Name": "wheel_FR_joint"
                     }
                 }
             }
@@ -867,19 +861,18 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 13299598668537444244
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 5938297682992751890,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "basic_platform",
-                        "Joint Name": "platform_base_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 7014737032381896820,
                     "Parent Entity": "Entity_[2519474926107]"
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 5938297682992751890,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "basic_platform",
+                        "Joint Name": "platform_base_joint"
+                    }
                 }
             }
         },
@@ -999,15 +992,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 15605763167411938660
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 4368675647580221482,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_CL",
-                        "Joint Name": "wheel_CL_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 10920974858884699363,
@@ -1018,6 +1002,14 @@
                             0.47581198811531067,
                             0.1469999998807907
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 4368675647580221482,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_CL",
+                        "Joint Name": "wheel_CL_joint"
                     }
                 }
             }
@@ -1227,15 +1219,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 11001398732714682120
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 4304561535272682067,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_RL",
-                        "Joint Name": "wheel_RL_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 18235508899209137899,
@@ -1246,6 +1229,14 @@
                             0.47581198811531067,
                             0.09000000357627869
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 4304561535272682067,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_RL",
+                        "Joint Name": "wheel_RL_joint"
                     }
                 }
             }
@@ -1362,15 +1353,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 12024648280213412067
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 5067399526360475740,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_RR",
-                        "Joint Name": "wheel_RR_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 9594692668350466101,
@@ -1381,6 +1363,14 @@
                             -0.47581198811531067,
                             0.09000000357627869
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 5067399526360475740,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_RR",
+                        "Joint Name": "wheel_RR_joint"
                     }
                 }
             }
@@ -1727,15 +1717,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 17014673235571821016
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 13899866913334024191,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_CR",
-                        "Joint Name": "wheel_CR_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 15489604726587043544,
@@ -1746,6 +1727,14 @@
                             -0.47581198811531067,
                             0.1469999998807907
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 13899866913334024191,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_CR",
+                        "Joint Name": "wheel_CR_joint"
                     }
                 }
             }
@@ -1980,14 +1969,6 @@
                         }
                     }
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 6097697814265899899,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "base_link"
-                    }
-                },
                 "ROS2RobotControlComponent": {
                     "$type": "GenericComponentWrapper",
                     "Id": 5405402406463899881,
@@ -2052,6 +2033,13 @@
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 15848641852368889391,
                     "Parent Entity": "ContainerEntity"
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 6097697814265899899,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "base_link"
+                    }
                 }
             }
         },

--- a/Assets/OTTO1500/OTTO1500_Lifting_platform.prefab
+++ b/Assets/OTTO1500/OTTO1500_Lifting_platform.prefab
@@ -570,19 +570,18 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 8543309040253375687
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 7797953199747721465,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "lifting_platform_base",
-                        "Joint Name": "platform_base_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 11008486067540714881,
                     "Parent Entity": "Entity_[1110725653019]"
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 7797953199747721465,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "lifting_platform_base",
+                        "Joint Name": "platform_base_joint"
+                    }
                 }
             }
         },
@@ -698,15 +697,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 17042451770518661582
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 15653938197853869814,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_FR",
-                        "Joint Name": "wheel_FR_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 12507719300496607560,
@@ -717,6 +707,14 @@
                             -0.47581198811531067,
                             0.09000000357627869
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 15653938197853869814,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_FR",
+                        "Joint Name": "wheel_FR_joint"
                     }
                 }
             }
@@ -951,14 +949,6 @@
                         }
                     }
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 846486765456039724,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "base_link"
-                    }
-                },
                 "ROS2RobotControlComponent": {
                     "$type": "GenericComponentWrapper",
                     "Id": 17648677164910155783,
@@ -1023,6 +1013,13 @@
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 1914697465706863652,
                     "Parent Entity": "ContainerEntity"
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 846486765456039724,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "base_link"
+                    }
                 }
             }
         },
@@ -1319,15 +1316,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 7132290279820186428
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 2315639252914940096,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_RR",
-                        "Joint Name": "wheel_RR_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 6287139759018839719,
@@ -1338,6 +1326,14 @@
                             -0.47581198811531067,
                             0.09000000357627869
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 2315639252914940096,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_RR",
+                        "Joint Name": "wheel_RR_joint"
                     }
                 }
             }
@@ -1454,15 +1450,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 599570099933479308
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 1405255309136561180,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_FL",
-                        "Joint Name": "wheel_FL_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 111102903236116066,
@@ -1473,6 +1460,14 @@
                             0.47581198811531067,
                             0.09000000357627869
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 1405255309136561180,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_FL",
+                        "Joint Name": "wheel_FL_joint"
                     }
                 }
             }
@@ -1589,15 +1584,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 15724415939963540995
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 4825142281503736763,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_RL",
-                        "Joint Name": "wheel_RL_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 3042598401775737989,
@@ -1608,6 +1594,14 @@
                             0.47581198811531067,
                             0.09000000357627869
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 4825142281503736763,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_RL",
+                        "Joint Name": "wheel_RL_joint"
                     }
                 }
             }
@@ -1728,15 +1722,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 10970369165200603987
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 5094852104546283434,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_CR",
-                        "Joint Name": "wheel_CR_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 664031309524572220,
@@ -1747,6 +1732,14 @@
                             -0.47581198811531067,
                             0.1469999998807907
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 5094852104546283434,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_CR",
+                        "Joint Name": "wheel_CR_joint"
                     }
                 }
             }
@@ -1999,15 +1992,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 16676920975958166214
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 6493275290702354821,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "lift_module",
-                        "Joint Name": "lift_module_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 7457908842884477803,
@@ -2018,6 +2002,14 @@
                             0.0,
                             0.3799999952316284
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 6493275290702354821,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "lift_module",
+                        "Joint Name": "lift_module_joint"
                     }
                 }
             }
@@ -2138,15 +2130,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 497181137057921449
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 15574975046981210750,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_CL",
-                        "Joint Name": "wheel_CL_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 2381514613129010332,
@@ -2157,6 +2140,14 @@
                             0.47581198811531067,
                             0.1469999998807907
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 15574975046981210750,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_CL",
+                        "Joint Name": "wheel_CL_joint"
                     }
                 }
             }
@@ -2368,19 +2359,18 @@
                         }
                     }
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 7624992504638885429,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "lift_upper",
-                        "Joint Name": "lift_upper_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 7231204767050711257,
                     "Parent Entity": "Entity_[1097840751131]"
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 7624992504638885429,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "lift_upper",
+                        "Joint Name": "lift_upper_joint"
+                    }
                 }
             }
         },
@@ -2606,13 +2596,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 13633123171021996394
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 9805679993737794881,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent"
-                    }
-                },
                 "ROS2Lidar2DSensorComponent": {
                     "$type": "GenericComponentWrapper",
                     "Id": 12388909980958955215,
@@ -2653,6 +2636,11 @@
                             -89.99999237060547
                         ]
                     }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 9805679993737794881,
+                    "ROS2FrameConfiguration": {}
                 }
             }
         },
@@ -4988,13 +4976,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 13633123171021996394
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 9805679993737794881,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent"
-                    }
-                },
                 "ROS2Lidar2DSensorComponent": {
                     "$type": "GenericComponentWrapper",
                     "Id": 12388909980958955215,
@@ -5035,6 +5016,11 @@
                             89.99998474121094
                         ]
                     }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 9805679993737794881,
+                    "ROS2FrameConfiguration": {}
                 }
             }
         }

--- a/Assets/OTTO600/OTTO600.prefab
+++ b/Assets/OTTO600/OTTO600.prefab
@@ -86,14 +86,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 13229562046516333863
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 1021054117381513344,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "sensor_frame_front"
-                    }
-                },
                 "ROS2Lidar2DSensorComponent": {
                     "$type": "GenericComponentWrapper",
                     "Id": 7190873393897941808,
@@ -135,6 +127,13 @@
                             0.0,
                             89.99993133544922
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 1021054117381513344,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "sensor_frame_front"
                     }
                 }
             }
@@ -350,14 +349,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 13229562046516333863
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 1021054117381513344,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "sensor_frame_rear"
-                    }
-                },
                 "ROS2Lidar2DSensorComponent": {
                     "$type": "GenericComponentWrapper",
                     "Id": 7190873393897941808,
@@ -399,6 +390,13 @@
                             0.0,
                             -90.00000762939453
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 1021054117381513344,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "sensor_frame_rear"
                     }
                 }
             }
@@ -2649,15 +2647,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 10525064806730949353
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 1685195339242614254,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_CR",
-                        "Joint Name": "wheel_CR_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 13836189155380994256,
@@ -2668,6 +2657,14 @@
                             -0.24199999868869781,
                             0.0877000018954277
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 1685195339242614254,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_CR",
+                        "Joint Name": "wheel_CR_joint"
                     }
                 }
             }
@@ -2799,15 +2796,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 3368377533465026419
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 5901806679755793469,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_RL",
-                        "Joint Name": "wheel_RL_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 5235209443845363675,
@@ -2818,6 +2806,14 @@
                             0.24199999868869781,
                             0.0877000018954277
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 5901806679755793469,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_RL",
+                        "Joint Name": "wheel_RL_joint"
                     }
                 }
             }
@@ -3102,14 +3098,6 @@
                         }
                     }
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 17397470648387535370,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "base_link"
-                    }
-                },
                 "ROS2OdometrySensorComponent": {
                     "$type": "GenericComponentWrapper",
                     "Id": 16264798095579696439,
@@ -3191,6 +3179,13 @@
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 10263502672085348284,
                     "Parent Entity": "ContainerEntity"
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 17397470648387535370,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "base_link"
+                    }
                 }
             }
         },
@@ -3382,15 +3377,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 6731356225539671618
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 1355237814141417055,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_FR",
-                        "Joint Name": "wheel_FR_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 2571948534174782925,
@@ -3401,6 +3387,14 @@
                             -0.24199999868869781,
                             0.0877000018954277
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 1355237814141417055,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_FR",
+                        "Joint Name": "wheel_FR_joint"
                     }
                 }
             }
@@ -3601,19 +3595,18 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 10910652991628068510
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 2174180570441989848,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "platform_base",
-                        "Joint Name": "platform_base_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 8278872072752172593,
                     "Parent Entity": "Entity_[376437113355]"
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 2174180570441989848,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "platform_base",
+                        "Joint Name": "platform_base_joint"
+                    }
                 }
             }
         },
@@ -3744,19 +3737,18 @@
                         }
                     }
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 13247078055354917866,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "platform_upper",
-                        "Joint Name": "platform_upper_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 9707263786250240503,
                     "Parent Entity": "Entity_[402206917131]"
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 13247078055354917866,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "platform_upper",
+                        "Joint Name": "platform_upper_joint"
+                    }
                 }
             }
         },
@@ -4152,15 +4144,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 7105857519706516029
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 6579705276849537004,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_CL",
-                        "Joint Name": "wheel_CL_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 2859753127298735767,
@@ -4171,6 +4154,14 @@
                             0.24199999868869781,
                             0.0877000018954277
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 6579705276849537004,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_CL",
+                        "Joint Name": "wheel_CL_joint"
                     }
                 }
             }
@@ -4363,15 +4354,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 1402539732528279026
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 1951075038113589187,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_RR",
-                        "Joint Name": "wheel_RR_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 238562926451881307,
@@ -4382,6 +4364,14 @@
                             -0.24199999868869781,
                             0.0877000018954277
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 1951075038113589187,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_RR",
+                        "Joint Name": "wheel_RR_joint"
                     }
                 }
             }
@@ -4664,15 +4654,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 10963743580669993920
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 360826664265524752,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_FL",
-                        "Joint Name": "wheel_FL_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 361678751970872990,
@@ -4683,6 +4664,14 @@
                             0.24199999868869781,
                             0.0877000018954277
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 360826664265524752,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_FL",
+                        "Joint Name": "wheel_FL_joint"
                     }
                 }
             }


### PR DESCRIPTION
Update prefabs to use the ROS2FrameEditorComponent (https://github.com/o3de/o3de-extras/pull/593).