### PR TITLE
Adjusted to Physx5 split, track/wheelbase fix

### DIFF
--- a/Assets/OTTO1500/OTTO1500_Basic_platform.prefab
+++ b/Assets/OTTO1500/OTTO1500_Basic_platform.prefab
@@ -86,12 +86,8 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 15925498669316666254
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 15123522658220298039,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent"
-                    }
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent"
                 },
                 "ROS2Lidar2DSensorComponent": {
                     "$type": "GenericComponentWrapper",
@@ -172,12 +168,8 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 15925498669316666254
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 15123522658220298039,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent"
-                    }
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent"
                 },
                 "ROS2Lidar2DSensorComponent": {
                     "$type": "GenericComponentWrapper",
@@ -427,11 +419,9 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 16022502127876327237
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 7074193684611987849,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "wheel_FL",
                         "Joint Name": "wheel_FL_joint"
                     }
@@ -562,11 +552,9 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 2443215881953371120
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 9575629714018252231,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "wheel_FR",
                         "Joint Name": "wheel_FR_joint"
                     }
@@ -867,11 +855,9 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 13299598668537444244
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 5938297682992751890,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "basic_platform",
                         "Joint Name": "platform_base_joint"
                     }
@@ -999,13 +985,12 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 15605763167411938660
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 4368675647580221482,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "wheel_CL",
-                        "Joint Name": "wheel_CL_joint"
+                        "Joint Name": "wheel_CL_joint",
+                        "Effective namespace": "base_link"
                     }
                 },
                 "TransformComponent": {
@@ -1018,6 +1003,14 @@
                             0.47581198811531067,
                             0.1469999998807907
                         ]
+                    }
+                },
+                "WheelControllerComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 15599042001081713666,
+                    "m_template": {
+                        "$type": "WheelControllerComponent",
+                        "SteeringEntity": ""
                     }
                 }
             }
@@ -1227,11 +1220,9 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 11001398732714682120
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 4304561535272682067,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "wheel_RL",
                         "Joint Name": "wheel_RL_joint"
                     }
@@ -1362,11 +1353,9 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 12024648280213412067
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 5067399526360475740,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "wheel_RR",
                         "Joint Name": "wheel_RR_joint"
                     }
@@ -1727,13 +1716,12 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 17014673235571821016
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 13899866913334024191,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "wheel_CR",
-                        "Joint Name": "wheel_CR_joint"
+                        "Joint Name": "wheel_CR_joint",
+                        "Effective namespace": "base_link"
                     }
                 },
                 "TransformComponent": {
@@ -1746,6 +1734,14 @@
                             -0.47581198811531067,
                             0.1469999998807907
                         ]
+                    }
+                },
+                "WheelControllerComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 10458837199657803817,
+                    "m_template": {
+                        "$type": "WheelControllerComponent",
+                        "SteeringEntity": ""
                     }
                 }
             }
@@ -1980,12 +1976,14 @@
                         }
                     }
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 6097697814265899899,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "base_link"
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "ROS2FrameConfiguration": {
+                        "Namespace Configuration": {
+                            "Namespace": "base_link"
+                        },
+                        "Frame Name": "base_link",
+                        "Effective namespace": "base_link"
                     }
                 },
                 "ROS2RobotControlComponent": {
@@ -2036,8 +2034,8 @@
                                     "WheelRadius": 0.09000000357627869
                                 }
                             ],
-                            "Track": 0.0,
-                            "Wheelbase": 0.8999999761581421
+                            "Track": 0.8999999761581421,
+                            "Wheelbase": 0.0
                         },
                         "DriveModel": {
                             "Limits": {

--- a/Assets/OTTO1500/OTTO1500_Lifting_platform.prefab
+++ b/Assets/OTTO1500/OTTO1500_Lifting_platform.prefab
@@ -570,19 +570,18 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 8543309040253375687
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 7797953199747721465,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "lifting_platform_base",
-                        "Joint Name": "platform_base_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 11008486067540714881,
                     "Parent Entity": "Entity_[1110725653019]"
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 7797953199747721465,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "lifting_platform_base",
+                        "Joint Name": "platform_base_joint"
+                    }
                 }
             }
         },
@@ -698,15 +697,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 17042451770518661582
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 15653938197853869814,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_FR",
-                        "Joint Name": "wheel_FR_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 12507719300496607560,
@@ -717,6 +707,14 @@
                             -0.47581198811531067,
                             0.09000000357627869
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 15653938197853869814,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_FR",
+                        "Joint Name": "wheel_FR_joint"
                     }
                 }
             }
@@ -951,14 +949,6 @@
                         }
                     }
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 846486765456039724,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "base_link"
-                    }
-                },
                 "ROS2RobotControlComponent": {
                     "$type": "GenericComponentWrapper",
                     "Id": 17648677164910155783,
@@ -1023,6 +1013,13 @@
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 1914697465706863652,
                     "Parent Entity": "ContainerEntity"
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 846486765456039724,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "base_link"
+                    }
                 }
             }
         },
@@ -1319,15 +1316,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 7132290279820186428
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 2315639252914940096,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_RR",
-                        "Joint Name": "wheel_RR_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 6287139759018839719,
@@ -1338,6 +1326,14 @@
                             -0.47581198811531067,
                             0.09000000357627869
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 2315639252914940096,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_RR",
+                        "Joint Name": "wheel_RR_joint"
                     }
                 }
             }
@@ -1454,15 +1450,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 599570099933479308
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 1405255309136561180,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_FL",
-                        "Joint Name": "wheel_FL_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 111102903236116066,
@@ -1473,6 +1460,14 @@
                             0.47581198811531067,
                             0.09000000357627869
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 1405255309136561180,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_FL",
+                        "Joint Name": "wheel_FL_joint"
                     }
                 }
             }
@@ -1589,15 +1584,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 15724415939963540995
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 4825142281503736763,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_RL",
-                        "Joint Name": "wheel_RL_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 3042598401775737989,
@@ -1608,6 +1594,14 @@
                             0.47581198811531067,
                             0.09000000357627869
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 4825142281503736763,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_RL",
+                        "Joint Name": "wheel_RL_joint"
                     }
                 }
             }
@@ -1728,15 +1722,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 10970369165200603987
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 5094852104546283434,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_CR",
-                        "Joint Name": "wheel_CR_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 664031309524572220,
@@ -1747,6 +1732,14 @@
                             -0.47581198811531067,
                             0.1469999998807907
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 5094852104546283434,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_CR",
+                        "Joint Name": "wheel_CR_joint"
                     }
                 }
             }
@@ -1999,15 +1992,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 16676920975958166214
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 6493275290702354821,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "lift_module",
-                        "Joint Name": "lift_module_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 7457908842884477803,
@@ -2018,6 +2002,14 @@
                             0.0,
                             0.3799999952316284
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 6493275290702354821,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "lift_module",
+                        "Joint Name": "lift_module_joint"
                     }
                 }
             }
@@ -2138,15 +2130,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 497181137057921449
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 15574975046981210750,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "wheel_CL",
-                        "Joint Name": "wheel_CL_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 2381514613129010332,
@@ -2157,6 +2140,14 @@
                             0.47581198811531067,
                             0.1469999998807907
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 15574975046981210750,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "wheel_CL",
+                        "Joint Name": "wheel_CL_joint"
                     }
                 }
             }
@@ -2368,19 +2359,18 @@
                         }
                     }
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 7624992504638885429,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "lift_upper",
-                        "Joint Name": "lift_upper_joint"
-                    }
-                },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 7231204767050711257,
                     "Parent Entity": "Entity_[1097840751131]"
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 7624992504638885429,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "lift_upper",
+                        "Joint Name": "lift_upper_joint"
+                    }
                 }
             }
         },
@@ -2606,13 +2596,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 13633123171021996394
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 9805679993737794881,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent"
-                    }
-                },
                 "ROS2Lidar2DSensorComponent": {
                     "$type": "GenericComponentWrapper",
                     "Id": 12388909980958955215,
@@ -2653,6 +2636,11 @@
                             -89.99999237060547
                         ]
                     }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 9805679993737794881,
+                    "ROS2FrameConfiguration": {}
                 }
             }
         },
@@ -4988,13 +4976,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 13633123171021996394
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 9805679993737794881,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent"
-                    }
-                },
                 "ROS2Lidar2DSensorComponent": {
                     "$type": "GenericComponentWrapper",
                     "Id": 12388909980958955215,
@@ -5035,6 +5016,11 @@
                             89.99998474121094
                         ]
                     }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 9805679993737794881,
+                    "ROS2FrameConfiguration": {}
                 }
             }
         }

--- a/Assets/OTTO600/OTTO600.prefab
+++ b/Assets/OTTO600/OTTO600.prefab
@@ -86,11 +86,9 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 13229562046516333863
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 1021054117381513344,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "sensor_frame_front"
                     }
                 },
@@ -350,11 +348,9 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 13229562046516333863
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 1021054117381513344,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "sensor_frame_rear"
                     }
                 },
@@ -2649,13 +2645,12 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 10525064806730949353
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 1685195339242614254,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "wheel_CR",
-                        "Joint Name": "wheel_CR_joint"
+                        "Joint Name": "wheel_CR_joint",
+                        "Effective namespace": "base_link"
                     }
                 },
                 "TransformComponent": {
@@ -2668,6 +2663,14 @@
                             -0.24199999868869781,
                             0.0877000018954277
                         ]
+                    }
+                },
+                "WheelControllerComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 10964316800536557406,
+                    "m_template": {
+                        "$type": "WheelControllerComponent",
+                        "SteeringEntity": ""
                     }
                 }
             }
@@ -2799,11 +2802,9 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 3368377533465026419
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 5901806679755793469,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "wheel_RL",
                         "Joint Name": "wheel_RL_joint"
                     }
@@ -3102,12 +3103,14 @@
                         }
                     }
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 17397470648387535370,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
-                        "Frame Name": "base_link"
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "ROS2FrameConfiguration": {
+                        "Namespace Configuration": {
+                            "Namespace": "base_link"
+                        },
+                        "Frame Name": "base_link",
+                        "Effective namespace": "base_link"
                     }
                 },
                 "ROS2OdometrySensorComponent": {
@@ -3174,8 +3177,8 @@
                                     "WheelRadius": 0.08699999749660492
                                 }
                             ],
-                            "Track": 0.0,
-                            "Wheelbase": 0.5699999928474426
+                            "Track": 0.5699999928474426,
+                            "Wheelbase": 0.0
                         },
                         "DriveModel": {
                             "Limits": {
@@ -3382,11 +3385,9 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 6731356225539671618
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 1355237814141417055,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "wheel_FR",
                         "Joint Name": "wheel_FR_joint"
                     }
@@ -3601,11 +3602,9 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 10910652991628068510
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 2174180570441989848,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "platform_base",
                         "Joint Name": "platform_base_joint"
                     }
@@ -3744,11 +3743,9 @@
                         }
                     }
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 13247078055354917866,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "platform_upper",
                         "Joint Name": "platform_upper_joint"
                     }
@@ -4152,13 +4149,12 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 7105857519706516029
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 6579705276849537004,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "wheel_CL",
-                        "Joint Name": "wheel_CL_joint"
+                        "Joint Name": "wheel_CL_joint",
+                        "Effective namespace": "base_link"
                     }
                 },
                 "TransformComponent": {
@@ -4171,6 +4167,14 @@
                             0.24199999868869781,
                             0.0877000018954277
                         ]
+                    }
+                },
+                "WheelControllerComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 10257214863012353919,
+                    "m_template": {
+                        "$type": "WheelControllerComponent",
+                        "SteeringEntity": ""
                     }
                 }
             }
@@ -4363,11 +4367,9 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 1402539732528279026
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 1951075038113589187,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "wheel_RR",
                         "Joint Name": "wheel_RR_joint"
                     }
@@ -4664,11 +4666,9 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 10963743580669993920
                 },
-                "ROS2FrameComponent": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 360826664265524752,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "ROS2FrameConfiguration": {
                         "Frame Name": "wheel_FL",
                         "Joint Name": "wheel_FL_joint"
                     }

--- a/gem.json
+++ b/gem.json
@@ -20,7 +20,7 @@
     "icon_path": "preview.png",
     "requirements": "This gem requires ROS2, and PhysX gems.",
     "dependencies": [
-        "ROS2",
+        "ROS2==3.0.0"
         "PhysX5"
     ],
     "repo_uri": "https://github.com/RobotecAI/o3de-otto-robots-gem",

--- a/gem.json
+++ b/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "OTTORobots",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "display_name": "OTTORobots",
     "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",
@@ -20,7 +20,7 @@
     "icon_path": "preview.png",
     "requirements": "This gem requires ROS2, and PhysX gems.",
     "dependencies": [
-        "ROS2==3.0.0"
+        "ROS2==3.1.0",
         "PhysX5"
     ],
     "repo_uri": "https://github.com/RobotecAI/o3de-otto-robots-gem",

--- a/gem.json
+++ b/gem.json
@@ -21,7 +21,7 @@
     "requirements": "This gem requires ROS2, and PhysX gems.",
     "dependencies": [
         "ROS2",
-        "PhysX"
+        "PhysX5"
     ],
     "repo_uri": "https://github.com/RobotecAI/o3de-otto-robots-gem",
     "restricted": "OTTORobots"


### PR DESCRIPTION
## What does this PR do?

This PR adjusts prefabs to recent changes in development:
- https://github.com/o3de/o3de/pull/17436
- https://github.com/o3de/o3de-extras/pull/593
- https://github.com/o3de/o3de-extras/pull/642

I've added wheels controllers and replaced wheel base and track.

## How was this PR tested?

Running a Roscon 2023 demo.