### PR TITLE
ROS2 version follows o3de-extras update

### DIFF
--- a/gem.json
+++ b/gem.json
@@ -20,7 +20,7 @@
     "icon_path": "preview.png",
     "requirements": "This gem requires ROS2, and PhysX gems.",
     "dependencies": [
-        "ROS2==3.1.0",
+        "ROS2>=3.1.0",
         "PhysX5"
     ],
     "repo_uri": "https://github.com/RobotecAI/o3de-otto-robots-gem",


### PR DESCRIPTION
There was recently an update on the `o3de-extras` repository related to the `ROS 2` gem's version. Version 3.1.0 is heading into the release and the version under development was bumped to 3.2.0. The development branch on this repository should work with both branches of `o3de-extras`.