### PR TITLE
Fix build error when using the O3DE SDK stabilization installer

### DIFF
--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -128,7 +128,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         BUILD_DEPENDENCIES
             PUBLIC
                 AZ::AzToolsFramework
-                $<TARGET_OBJECTS:Gem::${gem_name}.Private.Object>
+                ${gem_name}.Private.Object
     )
 
     ly_add_target(


### PR DESCRIPTION
This fixes the error which occurs when building from the O3DE SDK install build.

```
CMake Error: CMake can not determine linker language for target: OTTORobots.Editor.Private.Object
```
This applies the [fix](https://github.com/o3de/o3de/pull/17605)  to an earlier error.
