### PR TITLE
Add reference to AZ::Component in serialization

### DIFF
--- a/Code/Source/Lights/LightController.cpp
+++ b/Code/Source/Lights/LightController.cpp
@@ -49,7 +49,7 @@ namespace ROS2::OTTORobots
         LightControllerConfiguration::Reflect(context);
         if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serialize->Class<LightController>()->Version(1)->Field("configuration", &LightController::m_config);
+            serialize->Class<LightController, AZ::Component>()->Version(1)->Field("configuration", &LightController::m_config);
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
             {


### PR DESCRIPTION
The LightController had a bug in serialization that caused warnings when building with o3de 2409.1. 