### PR TITLE
Changes to meshes generation to work with o3de 2605

### DIFF
--- a/Assets/OTTO1500/Models/Otto1500.fbx.assetinfo
+++ b/Assets/OTTO1500/Models/Otto1500.fbx.assetinfo
@@ -1,0 +1,318 @@
+{
+    "values": [
+        {
+            "$type": "{5B03C8E6-8CEE-4DA0-A7FA-CD88689DD45B} MeshGroup",
+            "id": "{FED10A82-C80D-5883-AE43-12A241E3A865}",
+            "name": "Otto1500",
+            "NodeSelectionList": {
+                "unselectedNodes": [
+                    {},
+                    "RootNode",
+                    "RootNode.Otto1500_Body",
+                    "RootNode.Otto_Wheel_01_L",
+                    "RootNode.Otto_Wheel_01_R",
+                    "RootNode.Otto_Wheel_02_L",
+                    "RootNode.Otto_Wheel_02_R",
+                    "RootNode.Otto_Wheel_03_L",
+                    "RootNode.Otto_Wheel_03_R"
+                ]
+            },
+            "PhysicsMaterialSlots": {
+                "Slots": [
+                    {
+                        "Name": "Entire object"
+                    }
+                ]
+            }
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "Otto1500",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    {},
+                    "RootNode",
+                    "RootNode.Otto1500_Body",
+                    "RootNode.Otto_Wheel_01_L",
+                    "RootNode.Otto_Wheel_01_R",
+                    "RootNode.Otto_Wheel_02_L",
+                    "RootNode.Otto_Wheel_02_R",
+                    "RootNode.Otto_Wheel_03_L",
+                    "RootNode.Otto_Wheel_03_R"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "MaterialRule"
+                    },
+                    {
+                        "$type": "CoordinateSystemRule",
+                        "targetCoordinateSystem": 1,
+                        "useAdvancedData": true,
+                        "rotation": [
+                            0.0,
+                            0.0,
+                            0.7071067690849304,
+                            0.7071067094802856
+                        ]
+                    }
+                ]
+            },
+            "id": "{44EE32D6-D4CA-5157-B2D4-0BFEA0276615}"
+        },
+        {
+            "$type": "{41DCBEAB-203C-4A05-96FA-98E1D8A96FA1} ImportGroup"
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "default_Otto1500_094FAF62_8FDD_5A2F_B17F_653D4E786870_",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    "RootNode.Otto_Wheel_03_R"
+                ],
+                "unselectedNodes": [
+                    "RootNode.Otto1500_Body",
+                    "RootNode.Otto_Wheel_01_L",
+                    "RootNode.Otto_Wheel_01_R",
+                    "RootNode.Otto_Wheel_02_L",
+                    "RootNode.Otto_Wheel_02_R",
+                    "RootNode.Otto_Wheel_03_L"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "ProceduralMeshGroupRule"
+                    },
+                    {
+                        "$type": "UnmodifiableRule"
+                    },
+                    {
+                        "$type": "CoordinateSystemRule",
+                        "useAdvancedData": true
+                    },
+                    {
+                        "$type": "{6E796AC8-1484-4909-860A-6D3F22A7346F} LodRule"
+                    }
+                ]
+            },
+            "id": "{094FAF62-8FDD-5A2F-B17F-653D4E786870}"
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "default_Otto1500_B0C8B717_D8F4_53F3_AD74_B0B272029135_",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    "RootNode.Otto_Wheel_02_R"
+                ],
+                "unselectedNodes": [
+                    "RootNode.Otto1500_Body",
+                    "RootNode.Otto_Wheel_01_L",
+                    "RootNode.Otto_Wheel_01_R",
+                    "RootNode.Otto_Wheel_02_L",
+                    "RootNode.Otto_Wheel_03_L",
+                    "RootNode.Otto_Wheel_03_R"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "ProceduralMeshGroupRule"
+                    },
+                    {
+                        "$type": "UnmodifiableRule"
+                    },
+                    {
+                        "$type": "CoordinateSystemRule",
+                        "useAdvancedData": true
+                    },
+                    {
+                        "$type": "{6E796AC8-1484-4909-860A-6D3F22A7346F} LodRule"
+                    }
+                ]
+            },
+            "id": "{B0C8B717-D8F4-53F3-AD74-B0B272029135}"
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "default_Otto1500_C4D589FB_7AF1_5085_95FF_0FBC540EC325_",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    "RootNode.Otto_Wheel_02_L"
+                ],
+                "unselectedNodes": [
+                    "RootNode.Otto1500_Body",
+                    "RootNode.Otto_Wheel_01_L",
+                    "RootNode.Otto_Wheel_01_R",
+                    "RootNode.Otto_Wheel_02_R",
+                    "RootNode.Otto_Wheel_03_L",
+                    "RootNode.Otto_Wheel_03_R"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "ProceduralMeshGroupRule"
+                    },
+                    {
+                        "$type": "UnmodifiableRule"
+                    },
+                    {
+                        "$type": "CoordinateSystemRule",
+                        "useAdvancedData": true
+                    },
+                    {
+                        "$type": "{6E796AC8-1484-4909-860A-6D3F22A7346F} LodRule"
+                    }
+                ]
+            },
+            "id": "{C4D589FB-7AF1-5085-95FF-0FBC540EC325}"
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "default_Otto1500_336C0693_5218_5377_B4C0_24DB6416DB18_",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    "RootNode.Otto_Wheel_01_R"
+                ],
+                "unselectedNodes": [
+                    "RootNode.Otto1500_Body",
+                    "RootNode.Otto_Wheel_01_L",
+                    "RootNode.Otto_Wheel_02_L",
+                    "RootNode.Otto_Wheel_02_R",
+                    "RootNode.Otto_Wheel_03_L",
+                    "RootNode.Otto_Wheel_03_R"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "ProceduralMeshGroupRule"
+                    },
+                    {
+                        "$type": "UnmodifiableRule"
+                    },
+                    {
+                        "$type": "CoordinateSystemRule",
+                        "useAdvancedData": true
+                    },
+                    {
+                        "$type": "{6E796AC8-1484-4909-860A-6D3F22A7346F} LodRule"
+                    }
+                ]
+            },
+            "id": "{336C0693-5218-5377-B4C0-24DB6416DB18}"
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "default_Otto1500_CDE15FE7_5E1A_506B_AB65_0C1C49788B94_",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    "RootNode.Otto_Wheel_01_L"
+                ],
+                "unselectedNodes": [
+                    "RootNode.Otto1500_Body",
+                    "RootNode.Otto_Wheel_01_R",
+                    "RootNode.Otto_Wheel_02_L",
+                    "RootNode.Otto_Wheel_02_R",
+                    "RootNode.Otto_Wheel_03_L",
+                    "RootNode.Otto_Wheel_03_R"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "ProceduralMeshGroupRule"
+                    },
+                    {
+                        "$type": "UnmodifiableRule"
+                    },
+                    {
+                        "$type": "CoordinateSystemRule",
+                        "useAdvancedData": true
+                    },
+                    {
+                        "$type": "{6E796AC8-1484-4909-860A-6D3F22A7346F} LodRule"
+                    }
+                ]
+            },
+            "id": "{CDE15FE7-5E1A-506B-AB65-0C1C49788B94}"
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "default_Otto1500_7FE1971E_6773_5676_9271_7F2B7D88E0C7_",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    "RootNode.Otto1500_Body"
+                ],
+                "unselectedNodes": [
+                    "RootNode.Otto_Wheel_01_L",
+                    "RootNode.Otto_Wheel_01_R",
+                    "RootNode.Otto_Wheel_02_L",
+                    "RootNode.Otto_Wheel_02_R",
+                    "RootNode.Otto_Wheel_03_L",
+                    "RootNode.Otto_Wheel_03_R"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "ProceduralMeshGroupRule"
+                    },
+                    {
+                        "$type": "UnmodifiableRule"
+                    },
+                    {
+                        "$type": "CoordinateSystemRule",
+                        "useAdvancedData": true
+                    },
+                    {
+                        "$type": "{6E796AC8-1484-4909-860A-6D3F22A7346F} LodRule"
+                    }
+                ]
+            },
+            "id": "{7FE1971E-6773-5676-9271-7F2B7D88E0C7}"
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "default_Otto1500_E6481C7A_F87E_5857_ACCC_4E9E20B1468C_",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    "RootNode.Otto_Wheel_03_L"
+                ],
+                "unselectedNodes": [
+                    "RootNode.Otto1500_Body",
+                    "RootNode.Otto_Wheel_01_L",
+                    "RootNode.Otto_Wheel_01_R",
+                    "RootNode.Otto_Wheel_02_L",
+                    "RootNode.Otto_Wheel_02_R",
+                    "RootNode.Otto_Wheel_03_R"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "ProceduralMeshGroupRule"
+                    },
+                    {
+                        "$type": "UnmodifiableRule"
+                    },
+                    {
+                        "$type": "CoordinateSystemRule",
+                        "useAdvancedData": true
+                    },
+                    {
+                        "$type": "{6E796AC8-1484-4909-860A-6D3F22A7346F} LodRule"
+                    }
+                ]
+            },
+            "id": "{E6481C7A-F87E-5857-ACCC-4E9E20B1468C}"
+        },
+        {
+            "$type": "PrefabGroup",
+            "name": "OTTO1500/Models/Otto1500_fbx.procprefab",
+            "id": "{6B6C5179-8169-5692-8377-0966809AEB62}"
+        }
+    ]
+}

--- a/Assets/OTTO1500/Models/Otto1500_PlatformA.fbx.assetinfo
+++ b/Assets/OTTO1500/Models/Otto1500_PlatformA.fbx.assetinfo
@@ -1,0 +1,87 @@
+{
+    "values": [
+        {
+            "$type": "{5B03C8E6-8CEE-4DA0-A7FA-CD88689DD45B} MeshGroup",
+            "id": "{4ACA3A73-B4A4-5BEA-ADEA-AF4118300271}",
+            "name": "Otto1500_PlatformA",
+            "NodeSelectionList": {
+                "unselectedNodes": [
+                    {},
+                    "RootNode",
+                    "RootNode.Otto1500_Platform_A"
+                ]
+            },
+            "PhysicsMaterialSlots": {
+                "Slots": [
+                    {
+                        "Name": "Entire object"
+                    }
+                ]
+            }
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "Otto1500_PlatformA",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    {},
+                    "RootNode",
+                    "RootNode.Otto1500_Platform_A"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "MaterialRule"
+                    },
+                    {
+                        "$type": "CoordinateSystemRule",
+                        "useAdvancedData": true,
+                        "rotation": [
+                            0.0,
+                            0.0,
+                            0.7071067690849304,
+                            0.7071067094802856
+                        ]
+                    }
+                ]
+            },
+            "id": "{EEE3F2DD-4586-5C10-9C38-9287B474D3A9}"
+        },
+        {
+            "$type": "{41DCBEAB-203C-4A05-96FA-98E1D8A96FA1} ImportGroup"
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "default_Otto1500_PlatformA_5845A4B2_07EF_57F3_ABCA_14D4890AAFFA_",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    "RootNode.Otto1500_Platform_A"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "ProceduralMeshGroupRule"
+                    },
+                    {
+                        "$type": "UnmodifiableRule"
+                    },
+                    {
+                        "$type": "CoordinateSystemRule",
+                        "useAdvancedData": true
+                    },
+                    {
+                        "$type": "{6E796AC8-1484-4909-860A-6D3F22A7346F} LodRule"
+                    }
+                ]
+            },
+            "id": "{5845A4B2-07EF-57F3-ABCA-14D4890AAFFA}"
+        },
+        {
+            "$type": "PrefabGroup",
+            "name": "OTTO1500/Models/Otto1500_PlatformA_fbx.procprefab",
+            "id": "{2F48829C-3500-573A-B8D3-898FB6E3223A}"
+        }
+    ]
+}

--- a/Assets/OTTO1500/Models/Otto1500_PlatformB.fbx.assetinfo
+++ b/Assets/OTTO1500/Models/Otto1500_PlatformB.fbx.assetinfo
@@ -1,0 +1,278 @@
+{
+    "values": [
+        {
+            "$type": "{5B03C8E6-8CEE-4DA0-A7FA-CD88689DD45B} MeshGroup",
+            "id": "{C7AD39DE-9E4A-598B-90D3-1938FF3F1012}",
+            "name": "Otto1500_PlatformB",
+            "NodeSelectionList": {
+                "unselectedNodes": [
+                    "RootNode",
+                    "RootNode.Otto1500_Lift",
+                    "RootNode.Otto1500_Lift.Otto1500_PlatfromB_001",
+                    "RootNode.Otto1500_Lift.UVMap",
+                    "RootNode.Otto1500_Lift.custom_properties",
+                    "RootNode.Otto1500_Lift.transform",
+                    "RootNode.Otto1500_LiftUpper",
+                    "RootNode.Otto1500_LiftUpper.Otto1500_PlatfromB_001",
+                    "RootNode.Otto1500_LiftUpper.UVMap",
+                    "RootNode.Otto1500_LiftUpper.custom_properties",
+                    "RootNode.Otto1500_LiftUpper.transform",
+                    "RootNode.Otto1500_PlatformB",
+                    "RootNode.Otto1500_PlatformB.Otto1500_PlatfromB_001",
+                    "RootNode.Otto1500_PlatformB.UVMap",
+                    "RootNode.Otto1500_PlatformB.custom_properties",
+                    "RootNode.Otto1500_PlatformB.transform"
+                ]
+            },
+            "PhysicsMaterialSlots": {
+                "Slots": [
+                    {
+                        "Name": "Entire object"
+                    }
+                ]
+            }
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "Otto1500_PlatformB",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    "RootNode",
+                    "RootNode.Otto1500_Lift",
+                    "RootNode.Otto1500_Lift.Otto1500_PlatfromB_001",
+                    "RootNode.Otto1500_Lift.UVMap",
+                    "RootNode.Otto1500_Lift.custom_properties",
+                    "RootNode.Otto1500_Lift.transform",
+                    "RootNode.Otto1500_LiftUpper",
+                    "RootNode.Otto1500_LiftUpper.Otto1500_PlatfromB_001",
+                    "RootNode.Otto1500_LiftUpper.UVMap",
+                    "RootNode.Otto1500_LiftUpper.custom_properties",
+                    "RootNode.Otto1500_LiftUpper.transform",
+                    "RootNode.Otto1500_PlatformB",
+                    "RootNode.Otto1500_PlatformB.Otto1500_PlatfromB_001",
+                    "RootNode.Otto1500_PlatformB.UVMap",
+                    "RootNode.Otto1500_PlatformB.custom_properties",
+                    "RootNode.Otto1500_PlatformB.transform"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "MaterialRule"
+                    },
+                    {
+                        "$type": "CoordinateSystemRule",
+                        "targetCoordinateSystem": 1,
+                        "useAdvancedData": true,
+                        "originNodeName": "RootNode",
+                        "rotation": [
+                            0.0,
+                            0.0,
+                            0.7071067690849304,
+                            0.7071067094802856
+                        ]
+                    }
+                ]
+            },
+            "id": "{7459F077-18FA-5139-BD7F-35D1FB5651A5}"
+        },
+        {
+            "$type": "{41DCBEAB-203C-4A05-96FA-98E1D8A96FA1} ImportGroup"
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "default_Otto1500_PlatformB_004E443B_3C4A_5FEF_ACC2_382EEDD59412_",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    "RootNode.Otto1500_Lift"
+                ],
+                "unselectedNodes": [
+                    "RootNode.Otto1500_LiftUpper",
+                    "RootNode.Otto1500_PlatformB"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "ProceduralMeshGroupRule"
+                    },
+                    {
+                        "$type": "UnmodifiableRule"
+                    },
+                    {
+                        "$type": "CoordinateSystemRule",
+                        "useAdvancedData": true
+                    },
+                    {
+                        "$type": "{6E796AC8-1484-4909-860A-6D3F22A7346F} LodRule"
+                    }
+                ]
+            },
+            "id": "{004E443B-3C4A-5FEF-ACC2-382EEDD59412}"
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "default_Otto1500_PlatformB_F1FC7E1F_66DA_5F15_8730_803E536ED92B_",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    "RootNode.Otto1500_LiftUpper"
+                ],
+                "unselectedNodes": [
+                    "RootNode.Otto1500_Lift",
+                    "RootNode.Otto1500_PlatformB"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "ProceduralMeshGroupRule"
+                    },
+                    {
+                        "$type": "UnmodifiableRule"
+                    },
+                    {
+                        "$type": "CoordinateSystemRule",
+                        "useAdvancedData": true
+                    },
+                    {
+                        "$type": "{6E796AC8-1484-4909-860A-6D3F22A7346F} LodRule"
+                    }
+                ]
+            },
+            "id": "{F1FC7E1F-66DA-5F15-8730-803E536ED92B}"
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "default_Otto1500_PlatformB_970763D1_2966_5184_89AD_722079BCE450_",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    "RootNode.Otto1500_PlatformB"
+                ],
+                "unselectedNodes": [
+                    "RootNode.Otto1500_Lift",
+                    "RootNode.Otto1500_LiftUpper"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "ProceduralMeshGroupRule"
+                    },
+                    {
+                        "$type": "UnmodifiableRule"
+                    },
+                    {
+                        "$type": "CoordinateSystemRule",
+                        "useAdvancedData": true
+                    },
+                    {
+                        "$type": "{6E796AC8-1484-4909-860A-6D3F22A7346F} LodRule"
+                    }
+                ]
+            },
+            "id": "{970763D1-2966-5184-89AD-722079BCE450}"
+        },
+        {
+            "$type": "PrefabGroup",
+            "name": "OTTO1500/Models/Otto1500_PlatformB_fbx.procprefab",
+            "id": "{9CE97549-43C1-5B51-BBA2-45D9A5674D59}"
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "Otto1500_PlatformB_Platform",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    "RootNode.Otto1500_PlatformB"
+                ],
+                "unselectedNodes": [
+                    "RootNode",
+                    "RootNode.Otto1500_Lift",
+                    "RootNode.Otto1500_LiftUpper"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "MaterialRule"
+                    },
+                    {
+                        "$type": "CoordinateSystemRule",
+                        "useAdvancedData": true,
+                        "originNodeName": "RootNode",
+                        "rotation": [
+                            0.0,
+                            0.0,
+                            0.7071067690849304,
+                            0.7071067094802856
+                        ]
+                    }
+                ]
+            },
+            "id": "{0A400C3A-D5F1-4D0A-886F-6ECFFBB93FD9}"
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "Otto1500_PlatformB_LiftUpper",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    "RootNode.Otto1500_LiftUpper"
+                ],
+                "unselectedNodes": [
+                    "RootNode",
+                    "RootNode.Otto1500_Lift",
+                    "RootNode.Otto1500_PlatformB"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "MaterialRule"
+                    },
+                    {
+                        "$type": "CoordinateSystemRule",
+                        "useAdvancedData": true,
+                        "rotation": [
+                            0.0,
+                            0.0,
+                            0.7071067690849304,
+                            0.7071067094802856
+                        ]
+                    }
+                ]
+            },
+            "id": "{BDBB7F80-4A28-42C2-9563-B2FE2299B105}"
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "Otto1500_PlatformB_Lift",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    "RootNode.Otto1500_Lift"
+                ],
+                "unselectedNodes": [
+                    "RootNode",
+                    "RootNode.Otto1500_LiftUpper",
+                    "RootNode.Otto1500_PlatformB"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "MaterialRule"
+                    },
+                    {
+                        "$type": "CoordinateSystemRule",
+                        "useAdvancedData": true,
+                        "rotation": [
+                            0.0,
+                            0.0,
+                            0.7071067690849304,
+                            0.7071067094802856
+                        ]
+                    }
+                ]
+            },
+            "id": "{7E647D07-621E-4990-9977-5DE092AF8437}"
+        }
+    ]
+}

--- a/Assets/OTTO1500/OTTO1500_Basic_platform.prefab
+++ b/Assets/OTTO1500/OTTO1500_Basic_platform.prefab
@@ -1478,9 +1478,9 @@
                             "ModelAsset": {
                                 "assetId": {
                                     "guid": "{BA392652-9DEE-578F-ACAF-1EC2D166EF99}",
-                                    "subId": 277198576
+                                    "subId": 280463597
                                 },
-                                "assetHint": "otto1500/models/default_otto1500_7fe1971e_6773_5676_9271_7f2b7d88e0c7_.fbx.azmodel"
+                                "assetHint": "otto1500/models/otto1500.fbx.azmodel"
                             }
                         }
                     }
@@ -1616,7 +1616,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{15605589-1183-56B8-AAA7-11DEBC896C3F}"
-                                            }
+                                            },
+                                            "assetHint": "otto1500/materials/otto1500_otto_1500.azmaterial"
                                         }
                                     }
                                 }
@@ -2106,9 +2107,9 @@
                             "ModelAsset": {
                                 "assetId": {
                                     "guid": "{17837BE0-E058-5AA4-9EB3-A47D1D63F1CD}",
-                                    "subId": 274575712
+                                    "subId": 269519631
                                 },
-                                "assetHint": "otto1500/models/default_otto1500_platforma_5845a4b2_07ef_57f3_abca_14d4890aaffa_.fbx.azmodel"
+                                "assetHint": "otto1500/models/otto1500_platforma.fbx.azmodel"
                             }
                         }
                     }

--- a/Assets/OTTO1500/OTTO1500_Lifting_platform.prefab
+++ b/Assets/OTTO1500/OTTO1500_Lifting_platform.prefab
@@ -155,9 +155,9 @@
                             "ModelAsset": {
                                 "assetId": {
                                     "guid": "{10E28C68-0353-5293-B0F0-54D0EAB26525}",
-                                    "subId": 285002843
+                                    "subId": 272407046
                                 },
-                                "assetHint": "otto1500/models/default_otto1500_platformb_004e443b_3c4a_5fef_acc2_382eedd59412_.fbx.azmodel"
+                                "assetHint": "otto1500/models/otto1500_platformb_lift.fbx.azmodel"
                             }
                         }
                     }
@@ -253,9 +253,9 @@
                             "ModelAsset": {
                                 "assetId": {
                                     "guid": "{BA392652-9DEE-578F-ACAF-1EC2D166EF99}",
-                                    "subId": 277198576
+                                    "subId": 280463597
                                 },
-                                "assetHint": "otto1500/models/default_otto1500_7fe1971e_6773_5676_9271_7f2b7d88e0c7_.fbx.azmodel"
+                                "assetHint": "otto1500/models/otto1500.fbx.azmodel"
                             }
                         }
                     }
@@ -417,7 +417,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{A2DD811B-0126-5424-A422-BF24205667EF}"
-                                            }
+                                            },
+                                            "assetHint": "otto1500/materials/otto1500_otto_1500_lights_side.azmaterial"
                                         }
                                     }
                                 },
@@ -1224,9 +1225,9 @@
                             "ModelAsset": {
                                 "assetId": {
                                     "guid": "{10E28C68-0353-5293-B0F0-54D0EAB26525}",
-                                    "subId": 271666637
+                                    "subId": 284294281
                                 },
-                                "assetHint": "otto1500/models/default_otto1500_platformb_f1fc7e1f_66da_5f15_8730_803e536ed92b_.fbx.azmodel"
+                                "assetHint": "otto1500/models/otto1500_platformb_liftupper.fbx.azmodel"
                             }
                         }
                     }
@@ -2282,9 +2283,9 @@
                             "ModelAsset": {
                                 "assetId": {
                                     "guid": "{10E28C68-0353-5293-B0F0-54D0EAB26525}",
-                                    "subId": 274838011
+                                    "subId": 275120656
                                 },
-                                "assetHint": "otto1500/models/default_otto1500_platformb_970763d1_2966_5184_89ad_722079bce450_.fbx.azmodel"
+                                "assetHint": "otto1500/models/otto1500_platformb_platform.fbx.azmodel"
                             }
                         }
                     }

--- a/Assets/OTTO600/Models/Otto600.fbx.assetinfo
+++ b/Assets/OTTO600/Models/Otto600.fbx.assetinfo
@@ -1,0 +1,317 @@
+{
+    "values": [
+        {
+            "$type": "{5B03C8E6-8CEE-4DA0-A7FA-CD88689DD45B} MeshGroup",
+            "id": "{2DFB2E88-9BDE-5157-9FE8-0049617B62A6}",
+            "name": "Otto600",
+            "NodeSelectionList": {
+                "unselectedNodes": [
+                    {},
+                    "RootNode",
+                    "RootNode.OTTO600_Body",
+                    "RootNode.OTTO600_Wheel_Front_L",
+                    "RootNode.OTTO600_Wheel_Front_R",
+                    "RootNode.OTTO600_Wheel_Middle_L",
+                    "RootNode.OTTO600_Wheel_Middle_R",
+                    "RootNode.OTTO600_Wheel_Rear_L",
+                    "RootNode.OTTO600_Wheel_Rear_R"
+                ]
+            },
+            "PhysicsMaterialSlots": {
+                "Slots": [
+                    {
+                        "Name": "Entire object"
+                    }
+                ]
+            }
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "Otto600",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    {},
+                    "RootNode",
+                    "RootNode.OTTO600_Body",
+                    "RootNode.OTTO600_Wheel_Front_L",
+                    "RootNode.OTTO600_Wheel_Front_R",
+                    "RootNode.OTTO600_Wheel_Middle_L",
+                    "RootNode.OTTO600_Wheel_Middle_R",
+                    "RootNode.OTTO600_Wheel_Rear_L",
+                    "RootNode.OTTO600_Wheel_Rear_R"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "MaterialRule"
+                    },
+                    {
+                        "$type": "CoordinateSystemRule",
+                        "useAdvancedData": true,
+                        "rotation": [
+                            0.0,
+                            0.0,
+                            0.7071067690849304,
+                            0.7071067094802856
+                        ]
+                    }
+                ]
+            },
+            "id": "{B0FEF67B-1529-596E-B65C-7101E85E8A3B}"
+        },
+        {
+            "$type": "{41DCBEAB-203C-4A05-96FA-98E1D8A96FA1} ImportGroup"
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "default_Otto600_49FA25FB_DC1B_5803_A9FA_7B35F3BC74A3_",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    "RootNode.OTTO600_Wheel_Rear_R"
+                ],
+                "unselectedNodes": [
+                    "RootNode.OTTO600_Body",
+                    "RootNode.OTTO600_Wheel_Front_L",
+                    "RootNode.OTTO600_Wheel_Front_R",
+                    "RootNode.OTTO600_Wheel_Middle_L",
+                    "RootNode.OTTO600_Wheel_Middle_R",
+                    "RootNode.OTTO600_Wheel_Rear_L"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "ProceduralMeshGroupRule"
+                    },
+                    {
+                        "$type": "UnmodifiableRule"
+                    },
+                    {
+                        "$type": "CoordinateSystemRule",
+                        "useAdvancedData": true
+                    },
+                    {
+                        "$type": "{6E796AC8-1484-4909-860A-6D3F22A7346F} LodRule"
+                    }
+                ]
+            },
+            "id": "{49FA25FB-DC1B-5803-A9FA-7B35F3BC74A3}"
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "default_Otto600_C86766F9_51F5_556A_9C35_207A52F01D6E_",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    "RootNode.OTTO600_Wheel_Middle_R"
+                ],
+                "unselectedNodes": [
+                    "RootNode.OTTO600_Body",
+                    "RootNode.OTTO600_Wheel_Front_L",
+                    "RootNode.OTTO600_Wheel_Front_R",
+                    "RootNode.OTTO600_Wheel_Middle_L",
+                    "RootNode.OTTO600_Wheel_Rear_L",
+                    "RootNode.OTTO600_Wheel_Rear_R"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "ProceduralMeshGroupRule"
+                    },
+                    {
+                        "$type": "UnmodifiableRule"
+                    },
+                    {
+                        "$type": "CoordinateSystemRule",
+                        "useAdvancedData": true
+                    },
+                    {
+                        "$type": "{6E796AC8-1484-4909-860A-6D3F22A7346F} LodRule"
+                    }
+                ]
+            },
+            "id": "{C86766F9-51F5-556A-9C35-207A52F01D6E}"
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "default_Otto600_E95CBB6C_A0D9_5428_B08A_125AD0D8862D_",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    "RootNode.OTTO600_Wheel_Middle_L"
+                ],
+                "unselectedNodes": [
+                    "RootNode.OTTO600_Body",
+                    "RootNode.OTTO600_Wheel_Front_L",
+                    "RootNode.OTTO600_Wheel_Front_R",
+                    "RootNode.OTTO600_Wheel_Middle_R",
+                    "RootNode.OTTO600_Wheel_Rear_L",
+                    "RootNode.OTTO600_Wheel_Rear_R"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "ProceduralMeshGroupRule"
+                    },
+                    {
+                        "$type": "UnmodifiableRule"
+                    },
+                    {
+                        "$type": "CoordinateSystemRule",
+                        "useAdvancedData": true
+                    },
+                    {
+                        "$type": "{6E796AC8-1484-4909-860A-6D3F22A7346F} LodRule"
+                    }
+                ]
+            },
+            "id": "{E95CBB6C-A0D9-5428-B08A-125AD0D8862D}"
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "default_Otto600_96649E6A_50DD_567E_9598_89735F9B7C54_",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    "RootNode.OTTO600_Wheel_Front_R"
+                ],
+                "unselectedNodes": [
+                    "RootNode.OTTO600_Body",
+                    "RootNode.OTTO600_Wheel_Front_L",
+                    "RootNode.OTTO600_Wheel_Middle_L",
+                    "RootNode.OTTO600_Wheel_Middle_R",
+                    "RootNode.OTTO600_Wheel_Rear_L",
+                    "RootNode.OTTO600_Wheel_Rear_R"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "ProceduralMeshGroupRule"
+                    },
+                    {
+                        "$type": "UnmodifiableRule"
+                    },
+                    {
+                        "$type": "CoordinateSystemRule",
+                        "useAdvancedData": true
+                    },
+                    {
+                        "$type": "{6E796AC8-1484-4909-860A-6D3F22A7346F} LodRule"
+                    }
+                ]
+            },
+            "id": "{96649E6A-50DD-567E-9598-89735F9B7C54}"
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "default_Otto600_4362E880_5238_5F37_8198_381D47DE5D37_",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    "RootNode.OTTO600_Wheel_Front_L"
+                ],
+                "unselectedNodes": [
+                    "RootNode.OTTO600_Body",
+                    "RootNode.OTTO600_Wheel_Front_R",
+                    "RootNode.OTTO600_Wheel_Middle_L",
+                    "RootNode.OTTO600_Wheel_Middle_R",
+                    "RootNode.OTTO600_Wheel_Rear_L",
+                    "RootNode.OTTO600_Wheel_Rear_R"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "ProceduralMeshGroupRule"
+                    },
+                    {
+                        "$type": "UnmodifiableRule"
+                    },
+                    {
+                        "$type": "CoordinateSystemRule",
+                        "useAdvancedData": true
+                    },
+                    {
+                        "$type": "{6E796AC8-1484-4909-860A-6D3F22A7346F} LodRule"
+                    }
+                ]
+            },
+            "id": "{4362E880-5238-5F37-8198-381D47DE5D37}"
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "default_Otto600_ED0E5649_2EA6_5F43_9C76_7913172AEF7B_",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    "RootNode.OTTO600_Body"
+                ],
+                "unselectedNodes": [
+                    "RootNode.OTTO600_Wheel_Front_L",
+                    "RootNode.OTTO600_Wheel_Front_R",
+                    "RootNode.OTTO600_Wheel_Middle_L",
+                    "RootNode.OTTO600_Wheel_Middle_R",
+                    "RootNode.OTTO600_Wheel_Rear_L",
+                    "RootNode.OTTO600_Wheel_Rear_R"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "ProceduralMeshGroupRule"
+                    },
+                    {
+                        "$type": "UnmodifiableRule"
+                    },
+                    {
+                        "$type": "CoordinateSystemRule",
+                        "useAdvancedData": true
+                    },
+                    {
+                        "$type": "{6E796AC8-1484-4909-860A-6D3F22A7346F} LodRule"
+                    }
+                ]
+            },
+            "id": "{ED0E5649-2EA6-5F43-9C76-7913172AEF7B}"
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "default_Otto600_6560CBA6_11A3_5407_928B_86F6520CA249_",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    "RootNode.OTTO600_Wheel_Rear_L"
+                ],
+                "unselectedNodes": [
+                    "RootNode.OTTO600_Body",
+                    "RootNode.OTTO600_Wheel_Front_L",
+                    "RootNode.OTTO600_Wheel_Front_R",
+                    "RootNode.OTTO600_Wheel_Middle_L",
+                    "RootNode.OTTO600_Wheel_Middle_R",
+                    "RootNode.OTTO600_Wheel_Rear_R"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "ProceduralMeshGroupRule"
+                    },
+                    {
+                        "$type": "UnmodifiableRule"
+                    },
+                    {
+                        "$type": "CoordinateSystemRule",
+                        "useAdvancedData": true
+                    },
+                    {
+                        "$type": "{6E796AC8-1484-4909-860A-6D3F22A7346F} LodRule"
+                    }
+                ]
+            },
+            "id": "{6560CBA6-11A3-5407-928B-86F6520CA249}"
+        },
+        {
+            "$type": "PrefabGroup",
+            "name": "OTTO600/Models/Otto600_fbx.procprefab",
+            "id": "{1C2E6510-4F93-55DB-88C0-E644A666742C}"
+        }
+    ]
+}

--- a/Assets/OTTO600/OTTO600.prefab
+++ b/Assets/OTTO600/OTTO600.prefab
@@ -4741,9 +4741,9 @@
                             "ModelAsset": {
                                 "assetId": {
                                     "guid": "{695F0A5B-BA43-5816-8925-BE65AEB1ED8D}",
-                                    "subId": 274871622
+                                    "subId": 273650306
                                 },
-                                "assetHint": "otto600/models/default_otto600_ed0e5649_2ea6_5f43_9c76_7913172aef7b_.fbx.azmodel"
+                                "assetHint": "otto600/models/otto600.fbx.azmodel"
                             }
                         }
                     }

--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -54,7 +54,8 @@ ly_add_target(
         PUBLIC
         AZ::AzGameFramework
         Gem::Atom_AtomBridge.Static
-        Gem::ROS2.Static
+        Gem::ROS2.API
+        Gem::ROS2Controllers.API
         Gem::RecastNavigation.API
         Gem::EMotionFX.Static
 )
@@ -147,7 +148,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 Gem::${gem_name}.Editor.API
                 AZ::AzGameFramework
                 Gem::Atom_AtomBridge.Static
-                Gem::ROS2.Static
                 Gem::RecastNavigation.API
                 Gem::EMotionFX.Static
             PRIVATE

--- a/Code/Source/Lights/LightController.cpp
+++ b/Code/Source/Lights/LightController.cpp
@@ -15,7 +15,7 @@
 #include <AtomLyIntegration/CommonFeatures/CoreLights/AreaLightBus.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
 #include <ROS2/ROS2Bus.h>
-#include <ROS2/Utilities/ROS2Names.h>
+
 
 namespace OTTORobots
 {
@@ -85,12 +85,16 @@ namespace OTTORobots
     {
         auto* ros2Interface = ROS2::ROS2Interface::Get();
         AZ_Assert(ros2Interface, "ROS2 interface not available");
-        auto* ros2Frame = ROS2::Utils::GetGameOrEditorComponent<ROS2::ROS2FrameComponent>(GetEntity());
-        AZ_Assert(ros2Frame, "Missing ROS2FrameComponent");
-        AZStd::string topic = ROS2::ROS2Names::GetNamespacedName(ros2Frame->GetNamespace(), m_config.m_topicConfiguration.m_topic);
+
+        AZStd::string namespaceFromFrame;
+        ROS2::ROS2FrameComponentBus::EventResult(namespaceFromFrame, m_entity->GetId(), &ROS2::ROS2FrameComponentRequests::GetNamespace);
+
+        AZStd::string namespacedTopicName;
+        ROS2::ROS2NamesRequestBus::BroadcastResult(
+            namespacedTopicName, &ROS2::ROS2NamesRequestBus::Events::GetNamespacedName, namespaceFromFrame, m_config.m_topicConfiguration.m_topic);
 
         m_colorSubscriber = ros2Interface->GetNode()->create_subscription<std_msgs::msg::String>(
-            topic.c_str(),
+            namespacedTopicName.c_str(),
             m_config.m_topicConfiguration.GetQoS(),
             [&](std_msgs::msg::String msg)
             {

--- a/Code/Source/Scripting/LifterController.cpp
+++ b/Code/Source/Scripting/LifterController.cpp
@@ -15,9 +15,8 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/std/string/string.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
-#include <ROS2/Manipulation/MotorizedJoints/PidMotorControllerBus.h>
+#include <ROS2Controllers/Manipulation/MotorizedJoints/PidMotorControllerComponent.h>
 #include <ROS2/ROS2Bus.h>
-#include <ROS2/ROS2GemUtilities.h>
 #include <std_msgs/msg/detail/bool__struct.hpp>
 
 namespace OTTORobots
@@ -54,18 +53,22 @@ namespace OTTORobots
     {
         auto* ros2Interface = ROS2::ROS2Interface::Get();
         AZ_Assert(ros2Interface, "ROS2 interface not available");
-        auto* ros2Frame = ROS2::Utils::GetGameOrEditorComponent<ROS2::ROS2FrameComponent>(GetEntity());
-        AZ_Assert(ros2Frame, "Missing ROS2FrameComponent");
-        AZStd::string topic = ros2Frame->GetNamespace() + "/" + m_topicConfiguration.m_topic;
+
+        AZStd::string namespaceFromFrame;
+        ROS2::ROS2FrameComponentBus::EventResult(namespaceFromFrame, m_entity->GetId(), &ROS2::ROS2FrameComponentRequests::GetNamespace);
+
+        AZStd::string namespacedTopicName;
+        ROS2::ROS2NamesRequestBus::BroadcastResult(
+            namespacedTopicName, &ROS2::ROS2NamesRequestBus::Events::GetNamespacedName, namespaceFromFrame, m_topicConfiguration.m_topic);
 
         m_lifterTopicSubscriber = ros2Interface->GetNode()->create_subscription<std_msgs::msg::Bool>(
-            topic.c_str(),
+            namespacedTopicName.c_str(),
             m_topicConfiguration.GetQoS(),
             [&](std_msgs::msg::Bool msg)
             {
                 float setpoint = msg.data ? m_setpoint : 0.;
-                ROS2::PidMotorControllerRequestBus::Event(
-                    GetEntityId(), &ROS2::PidMotorControllerRequestBus::Events::SetSetpoint, setpoint);
+                ROS2Controllers::PidMotorControllerRequestBus::Event(
+                    GetEntityId(), &ROS2Controllers::PidMotorControllerRequestBus::Events::SetSetpoint, setpoint);
             });
     }
 

--- a/gem.json
+++ b/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "OTTORobots",
-    "version": "2.0.0",
+    "version": "3.0.0",
     "display_name": "OTTORobots",
     "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",
@@ -20,7 +20,8 @@
     "icon_path": "preview.png",
     "requirements": "This gem requires ROS2, and PhysX gems.",
     "dependencies": [
-        "ROS2>=3.1.0",
+        "ROS2>=4.1.0",
+        "ROS2Controllers",
         "PhysX5"
     ],
     "repo_uri": "https://github.com/RobotecAI/o3de-otto-robots-gem",

--- a/gem.json
+++ b/gem.json
@@ -21,7 +21,7 @@
     "requirements": "This gem requires ROS2, and PhysX gems.",
     "dependencies": [
         "ROS2>=4.1.0",
-        "ROS2Controllers",
+        "ROS2Controllers>=1.0.1",
         "PhysX5"
     ],
     "repo_uri": "https://github.com/RobotecAI/o3de-otto-robots-gem",


### PR DESCRIPTION
This pull request adds new asset info files for the `Otto1500`, `Otto1500_PlatformA`, and `Otto1500_PlatformB` models, and updates the `OTTO1500_Basic_platform.prefab` to reference these new assets and materials. The changes primarily improve asset organization and ensure the prefab uses the correct model and material references.

**New asset info files:**

- Added `Otto1500.fbx.assetinfo`, `Otto1500_PlatformA.fbx.assetinfo`, and `Otto1500_PlatformB.fbx.assetinfo` to define mesh groups, node selections, and import rules for each model. [[1]](diffhunk://#diff-80e295e0bef69a0437eb27494bfb912ef31354897c542f5f00f9a6adf5d575dcR1-R318) [[2]](diffhunk://#diff-f6991578da4db3ec0cffca157c2f9748102f231e6fa09ff27ee03af6d990125bR1-R87) [[3]](diffhunk://#diff-3ae9830d38efef0b90d42d6b5a84104a19d7d94121ca5f1ac58ade9cd717b807R1-R278)

**Prefab updates:**

- Updated the `ModelAsset` reference in `OTTO1500_Basic_platform.prefab` to use the main `otto1500.fbx.azmodel` asset instead of a previously auto-generated model asset.
- Added an explicit `assetHint` for the primary material in the prefab, ensuring it references `otto1500_otto_1500.azmaterial`.