### PR TITLE
Remove incorrect material links

### DIFF
--- a/Assets/OTTO1500/OTTO1500_Basic_platform.prefab
+++ b/Assets/OTTO1500/OTTO1500_Basic_platform.prefab
@@ -107,19 +107,6 @@
                                             "assetHint": "otto1500/platform/otto1500_platform_a/otto1500_platform_a.azmaterial"
                                         }
                                     }
-                                },
-                                {
-                                    "Key": {
-                                        "materialSlotStableId": 2084814471
-                                    },
-                                    "Value": {
-                                        "MaterialAsset": {
-                                            "assetId": {
-                                                "guid": "{04E9D43B-E513-5FF6-A57B-BDB421578BA9}"
-                                            },
-                                            "assetHint": "otto1500/platform/otto1500_platform_a/otto1500_platform_a_otto1500_platform_a.azmaterial"
-                                        }
-                                    }
                                 }
                             ]
                         }
@@ -2245,19 +2232,6 @@
                                                 "guid": "{D1437214-2ABC-5991-A249-480F6DE087E1}"
                                             },
                                             "assetHint": "otto1500/platform/otto1500_platform_a/otto1500_platform_a.azmaterial"
-                                        }
-                                    }
-                                },
-                                {
-                                    "Key": {
-                                        "materialSlotStableId": 2084814471
-                                    },
-                                    "Value": {
-                                        "MaterialAsset": {
-                                            "assetId": {
-                                                "guid": "{04E9D43B-E513-5FF6-A57B-BDB421578BA9}"
-                                            },
-                                            "assetHint": "otto1500/platform/otto1500_platform_a/otto1500_platform_a_otto1500_platform_a.azmaterial"
                                         }
                                     }
                                 }

--- a/Assets/OTTO1500/OTTO1500_Lifting_platform.prefab
+++ b/Assets/OTTO1500/OTTO1500_Lifting_platform.prefab
@@ -190,14 +190,13 @@
                             "materials": [
                                 {
                                     "Key": {
-                                        "materialSlotStableId": 2534313805
+                                        "materialSlotStableId": 1946394567
                                     },
                                     "Value": {
                                         "MaterialAsset": {
                                             "assetId": {
-                                                "guid": "{328613CB-F807-5275-A03D-C5141E9F7C57}"
-                                            },
-                                            "assetHint": "otto1500/platform/otto1500_platfrom_b/platformb_platfrom_b.azmaterial"
+                                                "guid": "{ECDF553D-D923-5103-9BE9-08C43056AAFA}"
+                                            }
                                         }
                                     }
                                 },
@@ -1260,14 +1259,13 @@
                             "materials": [
                                 {
                                     "Key": {
-                                        "materialSlotStableId": 2534313805
+                                        "materialSlotStableId": 1946394567
                                     },
                                     "Value": {
                                         "MaterialAsset": {
                                             "assetId": {
-                                                "guid": "{328613CB-F807-5275-A03D-C5141E9F7C57}"
-                                            },
-                                            "assetHint": "otto1500/platform/otto1500_platfrom_b/platformb_platfrom_b.azmaterial"
+                                                "guid": "{ECDF553D-D923-5103-9BE9-08C43056AAFA}"
+                                            }
                                         }
                                     }
                                 },
@@ -2318,14 +2316,13 @@
                             "materials": [
                                 {
                                     "Key": {
-                                        "materialSlotStableId": 2534313805
+                                        "materialSlotStableId": 1946394567
                                     },
                                     "Value": {
                                         "MaterialAsset": {
                                             "assetId": {
-                                                "guid": "{328613CB-F807-5275-A03D-C5141E9F7C57}"
-                                            },
-                                            "assetHint": "otto1500/platform/otto1500_platfrom_b/platformb_platfrom_b.azmaterial"
+                                                "guid": "{ECDF553D-D923-5103-9BE9-08C43056AAFA}"
+                                            }
                                         }
                                     }
                                 },

--- a/Assets/OTTO600/OTTO600.prefab
+++ b/Assets/OTTO600/OTTO600.prefab
@@ -3727,14 +3727,13 @@
                             "materials": [
                                 {
                                     "Key": {
-                                        "materialSlotStableId": 3210808310
+                                        "materialSlotStableId": 3382174916
                                     },
                                     "Value": {
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{849EB531-CF01-5844-9192-26779B70E87B}"
-                                            },
-                                            "assetHint": "otto600/platform/otto600platform_otto600platform.azmaterial"
+                                            }
                                         }
                                     }
                                 }
@@ -4120,14 +4119,13 @@
                             "materials": [
                                 {
                                     "Key": {
-                                        "materialSlotStableId": 3210808310
+                                        "materialSlotStableId": 3382174916
                                     },
                                     "Value": {
                                         "MaterialAsset": {
                                             "assetId": {
-                                                "guid": "{E33FDE83-F05B-5EFF-A68E-6D92FCBAF5C5}"
-                                            },
-                                            "assetHint": "prefabs/otto600-platform/otto600platform_otto600platform.azmaterial"
+                                                "guid": "{849EB531-CF01-5844-9192-26779B70E87B}"
+                                            }
                                         }
                                     }
                                 }


### PR DESCRIPTION
All three assets (meshes) were modified, which changed the ids for materials.
A new slow was added for `OTTO1500_Basic_platform`, but the old one was not removed. The materials were not added correctly to the remaining two prefabs.

This is fixed now and the errors as the one below are gone:
```
<15:47:10> [Warning] (AssetManager) - GetAsset called for asset which does not exist in asset catalog and cannot be loaded. Asset may be missing, not processed or moved. AssetId: {328613CB-F807-5275-A03D-C5141E9F7C57}:0
<15:47:10> [Error] (Prefab) - Failed to queue asset 'otto1500/platform/otto1500_platfrom_b/platformb_platfrom_b.azmaterial' ({328613CB-F807-5275-A03D-C5141E9F7C57}:00000000) of type '{522C7BE0-501D-463E-92C6-15184A2B7AD8}' for loading while entering game mode.
<15:47:10> [Warning] (AssetManager) - GetAsset called for asset which does not exist in asset catalog and cannot be loaded. Asset may be missing, not processed or moved. AssetId: {E33FDE83-F05B-5EFF-A68E-6D92FCBAF5C5}:0
<15:47:10> [Error] (Prefab) - Failed to queue asset 'prefabs/otto600-platform/otto600platform_otto600platform.azmaterial' ({E33FDE83-F05B-5EFF-A68E-6D92FCBAF5C5}:00000000) of type '{522C7BE0-501D-463E-92C6-15184A2B7AD8}' for loading while entering game mode.
<15:47:10> [Error] (Prefab) - Failed to queue asset 'otto1500/platform/otto1500_platfrom_b/platformb_platfrom_b.azmaterial' ({328613CB-F807-5275-A03D-C5141E9F7C57}:00000000) of type '{522C7BE0-501D-463E-92C6-15184A2B7AD8}' for loading while entering game mode.
<15:47:10> [Error] (Prefab) - Failed to queue asset 'otto1500/platform/otto1500_platfrom_b/platformb_platfrom_b.azmaterial' ({328613CB-F807-5275-A03D-C5141E9F7C57}:00000000) of type '{522C7BE0-501D-463E-92C6-15184A2B7AD8}' for loading while entering game mode.

```