### PR TITLE
Remove duplicated platform in OTTO1500

### DIFF
--- a/Assets/OTTO1500/OTTO1500_Basic_platform.prefab
+++ b/Assets/OTTO1500/OTTO1500_Basic_platform.prefab
@@ -890,7 +890,6 @@
                     "$type": "EditorEntitySortComponent",
                     "Id": 13717270301119892066,
                     "Child Entity Order": [
-                        "Entity_[2528064860699]",
                         "Entity_[1623676683678]"
                     ]
                 },
@@ -939,6 +938,7 @@
                 },
                 "ROS2FrameEditorComponent": {
                     "$type": "ROS2FrameEditorComponent",
+                    "Id": 3756522344248000981,
                     "ROS2FrameConfiguration": {
                         "Frame Name": "basic_platform",
                         "Joint Name": "platform_base_joint"
@@ -2174,87 +2174,6 @@
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 15848641852368889391,
                     "Parent Entity": "ContainerEntity"
-                }
-            }
-        },
-        "Entity_[2528064860699]": {
-            "Id": "Entity_[2528064860699]",
-            "Name": "basic_platform_visual",
-            "Components": {
-                "AZ::Render::EditorMeshComponent": {
-                    "$type": "AZ::Render::EditorMeshComponent",
-                    "Id": 3259034752661926442,
-                    "Controller": {
-                        "Configuration": {
-                            "ModelAsset": {
-                                "assetId": {
-                                    "guid": "{17837BE0-E058-5AA4-9EB3-A47D1D63F1CD}",
-                                    "subId": 269519631
-                                },
-                                "assetHint": "otto1500/models/otto1500_platforma.fbx.azmodel"
-                            }
-                        }
-                    }
-                },
-                "EditorDisabledCompositionComponent": {
-                    "$type": "EditorDisabledCompositionComponent",
-                    "Id": 14556346737118618979
-                },
-                "EditorEntityIconComponent": {
-                    "$type": "EditorEntityIconComponent",
-                    "Id": 7736610592776393321
-                },
-                "EditorEntitySortComponent": {
-                    "$type": "EditorEntitySortComponent",
-                    "Id": 15053338997561023912
-                },
-                "EditorInspectorComponent": {
-                    "$type": "EditorInspectorComponent",
-                    "Id": 2012677111403991911
-                },
-                "EditorLockComponent": {
-                    "$type": "EditorLockComponent",
-                    "Id": 4203834161933005483
-                },
-                "EditorMaterialComponent": {
-                    "$type": "EditorMaterialComponent",
-                    "Id": 8228673162048415399,
-                    "Controller": {
-                        "Configuration": {
-                            "materials": [
-                                {
-                                    "Key": {
-                                        "materialSlotStableId": 1900983038
-                                    },
-                                    "Value": {
-                                        "MaterialAsset": {
-                                            "assetId": {
-                                                "guid": "{D1437214-2ABC-5991-A249-480F6DE087E1}"
-                                            },
-                                            "assetHint": "otto1500/platform/otto1500_platform_a/otto1500_platform_a.azmaterial"
-                                        }
-                                    }
-                                }
-                            ]
-                        }
-                    }
-                },
-                "EditorOnlyEntityComponent": {
-                    "$type": "EditorOnlyEntityComponent",
-                    "Id": 5005434318419763258
-                },
-                "EditorPendingCompositionComponent": {
-                    "$type": "EditorPendingCompositionComponent",
-                    "Id": 4584594338792920262
-                },
-                "EditorVisibilityComponent": {
-                    "$type": "EditorVisibilityComponent",
-                    "Id": 9581402835971478273
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 11427576186611773679,
-                    "Parent Entity": "Entity_[2472230285851]"
                 }
             }
         },


### PR DESCRIPTION
`OTTO1500 Platform A` used to have a duplicated visual asset for the platform. This is fixed now.