### PR TITLE
Updated both OTTO1500 prefabs

### DIFF
--- a/Assets/OTTO1500/OTTO1500_Basic_platform.prefab
+++ b/Assets/OTTO1500/OTTO1500_Basic_platform.prefab
@@ -168,7 +168,11 @@
                     "Id": 15925498669316666254
                 },
                 "ROS2FrameEditorComponent": {
-                    "$type": "ROS2FrameEditorComponent"
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 14395560590681446260,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "sensor_frame_front"
+                    }
                 },
                 "ROS2Lidar2DSensorComponent": {
                     "$type": "GenericComponentWrapper",
@@ -179,7 +183,7 @@
                             "Publishers": {
                                 "sensor_msgs::msg::LaserScan": {
                                     "Type": "sensor_msgs::msg::LaserScan",
-                                    "Topic": "ls"
+                                    "Topic": "scan_front"
                                 }
                             }
                         },
@@ -250,7 +254,11 @@
                     "Id": 15925498669316666254
                 },
                 "ROS2FrameEditorComponent": {
-                    "$type": "ROS2FrameEditorComponent"
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 14931014348454295155,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "sensor_frame_rear"
+                    }
                 },
                 "ROS2Lidar2DSensorComponent": {
                     "$type": "GenericComponentWrapper",
@@ -261,7 +269,7 @@
                             "Publishers": {
                                 "sensor_msgs::msg::LaserScan": {
                                     "Type": "sensor_msgs::msg::LaserScan",
-                                    "Topic": "ls"
+                                    "Topic": "scan_rear"
                                 }
                             }
                         },
@@ -2103,11 +2111,27 @@
                 },
                 "ROS2FrameEditorComponent": {
                     "$type": "ROS2FrameEditorComponent",
+                    "Id": 1407404889281694566,
                     "ROS2FrameConfiguration": {
                         "Namespace Configuration": {
                             "Namespace": "base_link"
                         },
                         "Frame Name": "base_link"
+                    }
+                },
+                "ROS2OdometrySensorComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 5362437566902083660,
+                    "m_template": {
+                        "$type": "ROS2OdometrySensorComponent",
+                        "SensorConfiguration": {
+                            "Publishers": {
+                                "nav_msgs::msg::Odometry": {
+                                    "Type": "nav_msgs::msg::Odometry",
+                                    "Topic": "odom"
+                                }
+                            }
+                        }
                     }
                 },
                 "ROS2RobotControlComponent": {

--- a/Assets/OTTO1500/OTTO1500_Basic_platform.prefab
+++ b/Assets/OTTO1500/OTTO1500_Basic_platform.prefab
@@ -510,6 +510,7 @@
                 },
                 "ROS2FrameEditorComponent": {
                     "$type": "ROS2FrameEditorComponent",
+                    "Id": 18394442443977061473,
                     "ROS2FrameConfiguration": {
                         "Frame Name": "wheel_FL",
                         "Joint Name": "wheel_FL_joint"
@@ -643,6 +644,7 @@
                 },
                 "ROS2FrameEditorComponent": {
                     "$type": "ROS2FrameEditorComponent",
+                    "Id": 6143413863335963465,
                     "ROS2FrameConfiguration": {
                         "Frame Name": "wheel_FR",
                         "Joint Name": "wheel_FR_joint"
@@ -1077,6 +1079,7 @@
                 },
                 "ROS2FrameEditorComponent": {
                     "$type": "ROS2FrameEditorComponent",
+                    "Id": 530678386239137035,
                     "ROS2FrameConfiguration": {
                         "Frame Name": "wheel_CL",
                         "Joint Name": "wheel_CL_joint"
@@ -1311,6 +1314,7 @@
                 },
                 "ROS2FrameEditorComponent": {
                     "$type": "ROS2FrameEditorComponent",
+                    "Id": 9163406521615730848,
                     "ROS2FrameConfiguration": {
                         "Frame Name": "wheel_RL",
                         "Joint Name": "wheel_RL_joint"
@@ -1444,6 +1448,7 @@
                 },
                 "ROS2FrameEditorComponent": {
                     "$type": "ROS2FrameEditorComponent",
+                    "Id": 3578407789853348085,
                     "ROS2FrameConfiguration": {
                         "Frame Name": "wheel_RR",
                         "Joint Name": "wheel_RR_joint"
@@ -1852,6 +1857,7 @@
                 },
                 "ROS2FrameEditorComponent": {
                     "$type": "ROS2FrameEditorComponent",
+                    "Id": 12589057346966670610,
                     "ROS2FrameConfiguration": {
                         "Frame Name": "wheel_CR",
                         "Joint Name": "wheel_CR_joint"

--- a/Assets/OTTO1500/OTTO1500_Lifting_platform.prefab
+++ b/Assets/OTTO1500/OTTO1500_Lifting_platform.prefab
@@ -196,7 +196,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{ECDF553D-D923-5103-9BE9-08C43056AAFA}"
-                                            }
+                                            },
+                                            "assetHint": "otto1500/platform/otto1500_platfrom_b/otto1500_platform_b.azmaterial"
                                         }
                                     }
                                 },
@@ -1049,7 +1050,26 @@
                     "$type": "ROS2FrameEditorComponent",
                     "Id": 846486765456039724,
                     "ROS2FrameConfiguration": {
+                        "Namespace Configuration": {
+                            "Namespace": "base_link"
+                        },
                         "Frame Name": "base_link"
+                    }
+                },
+                "ROS2OdometrySensorComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 7264798095579696440,
+                    "m_template": {
+                        "$type": "ROS2OdometrySensorComponent",
+                        "SensorConfiguration": {
+                            "Frequency (HZ)": 100.0,
+                            "Publishers": {
+                                "nav_msgs::msg::Odometry": {
+                                    "Type": "nav_msgs::msg::Odometry",
+                                    "Topic": "odom"
+                                }
+                            }
+                        }
                     }
                 },
                 "ROS2RobotControlComponent": {
@@ -1265,7 +1285,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{ECDF553D-D923-5103-9BE9-08C43056AAFA}"
-                                            }
+                                            },
+                                            "assetHint": "otto1500/platform/otto1500_platfrom_b/otto1500_platform_b.azmaterial"
                                         }
                                     }
                                 },
@@ -2322,7 +2343,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{ECDF553D-D923-5103-9BE9-08C43056AAFA}"
-                                            }
+                                            },
+                                            "assetHint": "otto1500/platform/otto1500_platfrom_b/otto1500_platform_b.azmaterial"
                                         }
                                     }
                                 },
@@ -2720,7 +2742,10 @@
                 },
                 "ROS2FrameEditorComponent": {
                     "$type": "ROS2FrameEditorComponent",
-                    "Id": 9805679993737794881
+                    "Id": 9805679993737794881,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "sensor_frame_rear"
+                    }
                 },
                 "ROS2Lidar2DSensorComponent": {
                     "$type": "GenericComponentWrapper",
@@ -2731,7 +2756,7 @@
                             "Publishers": {
                                 "sensor_msgs::msg::LaserScan": {
                                     "Type": "sensor_msgs::msg::LaserScan",
-                                    "Topic": "ls"
+                                    "Topic": "scan_rear"
                                 }
                             }
                         },
@@ -5099,7 +5124,10 @@
                 },
                 "ROS2FrameEditorComponent": {
                     "$type": "ROS2FrameEditorComponent",
-                    "Id": 9805679993737794881
+                    "Id": 9805679993737794881,
+                    "ROS2FrameConfiguration": {
+                        "Frame Name": "sensor_frame_front"
+                    }
                 },
                 "ROS2Lidar2DSensorComponent": {
                     "$type": "GenericComponentWrapper",
@@ -5110,7 +5138,7 @@
                             "Publishers": {
                                 "sensor_msgs::msg::LaserScan": {
                                     "Type": "sensor_msgs::msg::LaserScan",
-                                    "Topic": "ls"
+                                    "Topic": "scan_front"
                                 }
                             }
                         },


### PR DESCRIPTION
As in the title, this PR fixes lidar topics (from generic `ls` to `scan_front` and `scan_rear` as in the OTTO600), renames the ROS 2 frame associated with a lidar entity (again - following the same pattern as in the OTTO600 prefab) and adds ROS2OdometrySensorComponent (again - as in the OTTO600 prefab).